### PR TITLE
Favicon & Page Names!

### DIFF
--- a/src/pages/about.js
+++ b/src/pages/about.js
@@ -8,7 +8,6 @@ import "../styles/all.css"
 import AboutComponent from "../components/aboutComponent" // everything relating to the images
 
 import Grid from '@mui/material/Grid';
-import { Divider } from "@mui/material";
 
 function AboutPage({ data }) {
 
@@ -228,3 +227,10 @@ export const query = graphql`
 `;
 
 export default AboutPage;
+
+export const Head = () => (
+  <>
+  <link rel="icon" type="image/png" href="https://educast.library.gatech.edu/static/empbytes-8c9db7ee75f110e619f7d85cb8b170c5.jpg" />
+  <title>About</title>
+  </>
+  )

--- a/src/pages/appteam.js
+++ b/src/pages/appteam.js
@@ -16,6 +16,7 @@ import "../styles/all.css"
 function App() {
     return(
         <Layout>
+            <title>App Team</title>
             <div className="top-banner" style={{backgroundImage: `linear-gradient(to bottom, rgba(0, 0, 0, 1), rgba(0, 0, 0, 0.5)), url(${Banner})`}}>
                 <h1 className="header-experiences">App Team</h1>
                 </div>

--- a/src/pages/contact.js
+++ b/src/pages/contact.js
@@ -93,3 +93,10 @@ function ContactPage() {
 }
 
 export default ContactPage;
+
+export const Head = () => (
+  <>
+  <link rel="icon" type="image/png" href="https://educast.library.gatech.edu/static/empbytes-8c9db7ee75f110e619f7d85cb8b170c5.jpg" />
+  <title>Contact</title>
+  </>
+  )

--- a/src/pages/emergingtech.js
+++ b/src/pages/emergingtech.js
@@ -21,6 +21,7 @@ import "../styles/all.css"
 function EmergingTech() {
     return(
         <Layout>
+            <title>Emerging Tech Team</title>
             <div className="top-banner" style={{backgroundImage: `linear-gradient(to bottom, rgba(0, 0, 0, 1), rgba(0, 0, 0, 0.5)), url(${Banner})`}}>
                 <h1 className="header-experiences">Emerging Technologies Team</h1>
             </div>

--- a/src/pages/experiences.js
+++ b/src/pages/experiences.js
@@ -180,3 +180,10 @@ function ExperiencesPage() {
 }
 
 export default ExperiencesPage;
+
+export const Head = () => (
+  <>
+  <link rel="icon" type="image/png" href="https://educast.library.gatech.edu/static/empbytes-8c9db7ee75f110e619f7d85cb8b170c5.jpg" />
+  <title>Experiences</title>
+  </>
+  )

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -125,4 +125,9 @@ function IndexPage() {
 
 export default IndexPage;
 
-export const Head = () => <title>Home Page</title>
+export const Head = () => (
+<>
+<link rel="icon" type="image/png" href="https://educast.library.gatech.edu/static/empbytes-8c9db7ee75f110e619f7d85cb8b170c5.jpg" />
+<title>Home</title>
+</>
+)

--- a/src/pages/mediateam.js
+++ b/src/pages/mediateam.js
@@ -12,6 +12,7 @@ import "../styles/all.css"
 function Media() {
     return(
         <Layout>
+            <title>Media Team</title>
             <div className="top-banner" style={{backgroundImage: `linear-gradient(to bottom, rgba(0, 0, 0, 1), rgba(0, 0, 0, 0.5)), url(${Banner})`}}>
                 <h1 className="header-experiences">Media Team</h1>
             </div>

--- a/src/pages/projects.js
+++ b/src/pages/projects.js
@@ -149,6 +149,13 @@ const ProjectsPage = ({data}) => {
 
 export default ProjectsPage;
 
+export const Head = () => (
+    <>
+    <link rel="icon" type="image/png" href="https://educast.library.gatech.edu/static/empbytes-8c9db7ee75f110e619f7d85cb8b170c5.jpg" />
+    <title>Projects</title>
+    </>
+    )
+
 // Query all collections
 export const query = graphql`
     query collectionQuery {

--- a/src/pages/webteam.js
+++ b/src/pages/webteam.js
@@ -10,7 +10,6 @@ import Grid from '@mui/material/Grid';
 
 import "../styles/experiencesIndividual.css";
 import "../styles/all.css";
-import { Title } from "@mui/icons-material";
 
 function web() {
     return(

--- a/src/pages/webteam.js
+++ b/src/pages/webteam.js
@@ -52,7 +52,7 @@ function web() {
 
                     <Grid item xs={12}>
                         <div className="blue-box" style={{width: "920px", display: "flex", justifyContent: "center"}}>
-                            <img src={technologies} style={{width:"50%"}}/>
+                            <img src={technologies} style={{width:"50%"}} alt="Gatsby and Drupal Logo"/>
                         </div>
                     </Grid>
                 </Grid>

--- a/src/pages/webteam.js
+++ b/src/pages/webteam.js
@@ -10,10 +10,12 @@ import Grid from '@mui/material/Grid';
 
 import "../styles/experiencesIndividual.css";
 import "../styles/all.css";
+import { Title } from "@mui/icons-material";
 
 function web() {
     return(
         <Layout>
+            <title>Web Team</title>
             <div className="top-banner" style={{backgroundImage: `linear-gradient(to bottom, rgba(0, 0, 0, 1), rgba(0, 0, 0, 0.5)), url(${Banner})`}}>
                 <h1 className="header-experiences">Web Team</h1>
             </div>

--- a/src/pages/webteam.js
+++ b/src/pages/webteam.js
@@ -81,3 +81,10 @@ function web() {
 }
 
 export default web;
+
+export const Head = () => (
+    <>
+    <link rel="icon" type="image/png" href="https://educast.library.gatech.edu/static/empbytes-8c9db7ee75f110e619f7d85cb8b170c5.jpg" />
+    <title>Web Team</title>
+    </>
+    )

--- a/src/templates/article.js
+++ b/src/templates/article.js
@@ -14,6 +14,7 @@ function Article({data}) {
 
     return (
         <Layout>
+            <title>{[post.title]}</title>
             <div className="articleContainer">
             {post.relationships.field_audio && 
                 <div className="articleImageContainer">

--- a/src/templates/collection.js
+++ b/src/templates/collection.js
@@ -33,6 +33,7 @@ function Collection({ data }) {
 
     return (
         <Layout>
+            <title>{collection.title}</title>
             <div style={container}>
                 <h1 style={collection_name}>{collection.title}</h1>
                 <div dangerouslySetInnerHTML={{ __html: collection.body.processed }} />


### PR DESCRIPTION
# Problem
Our website currently only displays a favicon on some of our pages, and we only display a page name on the home page. This makes the website feel rough around the edges, and it also makes it harder for users with screen readers to navigate our site.

## Fix
Each page now has the EmpathyBytes logo as its favicon, and it's page name is the same as the title of the page. This should make the website feel more consistent as well as make it more accessible.

## Pictures
The pictures below display how the Experiences page on the website looked like in the browser tab UI, before and after this change.

### Before
![image](https://github.com/user-attachments/assets/0007df38-936d-47f6-b6e5-245d11f15826)

### After
![image](https://github.com/user-attachments/assets/a1a2ea0d-463b-4e30-85a7-029599994899)

## Minor Accessibility Improvement:
* Added `alt` attribute to the image in `src/pages/webteam.js` to improve accessibility.
* More images will receive alt attributes as I work on code cleanup, this is just one of the ones I caught while working on this ticket.