### PR TITLE
Media Player Fix

### DIFF
--- a/src/templates/article.js
+++ b/src/templates/article.js
@@ -21,7 +21,7 @@ function Article({data}) {
                     <div className="articleTitleInfo">
                         <h1 className="articleTitle">{post.title}</h1>
                         <h3 className="authorInfo"> By {post.field_author}</h3>
-                        <audio className="articleAudio" src = {post.relationships.field_audio != null ? "https://www.empathybytes.library.gatech.edu" + post.relationships.field_audio.path.alias : null} controls>
+                        <audio className="articleAudio" src = {post.relationships.field_audio != null ? "https://empathybytes.library.gatech.edu" + post.relationships.field_audio.path.alias : null} controls>
                         </audio>
                     </div>
                 </div>


### PR DESCRIPTION
**The entire issue is outlined in Issue #21** 

### **Summary**

The audio clips are not working for any of the "Project" interviews because the baseURL was changed and was not updated across all the files. This will be added as a task in the future so that if the URL is ever changed again, it only has to be updated in one place.

**Before** - (shown page: http://localhost:8000/projects/makerspaces/Dane-Wrye-on-The-Hive-Community/)
![image](https://github.com/user-attachments/assets/2af73c8c-b2b9-48d3-b6c2-5851ffd6935b)



**After** - (shown page: http://localhost:8000/projects/makerspaces/Dane-Wrye-on-The-Hive-Community/)
![image](https://github.com/user-attachments/assets/7b3dfb13-a097-42a2-aa4d-a4545cdec9ea)
