### PR TITLE
Converted Current CSS files: articlePreview, footer, infocard, and interviewcard.css

### DIFF
--- a/src/styles/components/articlePreview.css
+++ b/src/styles/components/articlePreview.css
@@ -1,5 +1,6 @@
 @import "../fonts.css";
 
+/* used for past member page*/
 .paper {
     width: 80vw;
     margin: auto;
@@ -38,9 +39,9 @@
 }
 
 .past-image {
-    width: 125px;
-    height: 125px;
-    border-radius: 100px;
+    width: 10vw;
+    height: 10vw;
+    border-radius: 50%;
 }
 
 .card-past {

--- a/src/styles/components/footer.css
+++ b/src/styles/components/footer.css
@@ -5,15 +5,15 @@
     justify-content: space-evenly;
     display: flex;
     width: 100%; 
-    height: 320px;
+    height: 40vh;
     flex-direction: row;
-    padding: 70px 20px 0px 20px;
+    padding: 4rem 1rem 0 1rem;
 }
 
 .bytes {
-    display: block;       /* Makes 'Bytes' appear on a new line */  /* Adjust the size as needed */
+    display: block;       /* Makes 'Bytes' appear on a new line */  
     margin-top: 0.5rem;
-    text-align: left;  /* Add some space between the two words */
+    text-align: left; 
 }
 
 footer a:link{
@@ -28,9 +28,10 @@ footer a:hover{
     color:#90c7fa;
 }
 
+/*right icon*/
 .icon {
-    width:40px;
-    height:40px;
+    width:2.5rem;
+    height:2.5rem;
 }
 
 .icon-group {
@@ -40,13 +41,16 @@ footer a:hover{
     align-items: center;
 }
 
+/* group for general/teams/community */
+
 .grouping {
     display: flex;
     flex-direction: column;
     text-align: left;
-    align-items: center;
+    align-items: flex-start; 
+    /* fixed alignment issue */
     
-    margin-top: 40px;
+    margin-top: 5vh;
    
 }
 
@@ -62,10 +66,11 @@ footer a:hover{
 .text-heading {
     color: #FFF;
     font-family: Roboto;
-    font-size: 28px;
+    font-size: 1.75rem;
     font-style: normal;
     font-weight: 700;
     line-height: normal;
+    text-align: left;
 }
 
 .centered-content {
@@ -79,14 +84,18 @@ footer a:hover{
     display: flex;
     flex-direction: column;
     align-items: flex-start;
-    gap: 10px;
+    gap: 1.7vh;
     align-self: stretch; 
+
+    min-width: 50%;
+    max-width: 100%;
+    
 }
 
 .text-anchor {
     color: #FFF;
     font-family: Roboto;
-    font-size: 18px;
+    font-size: 1.125rem;
     font-style: normal;
     font-weight: 400;
     line-height: normal;
@@ -97,13 +106,14 @@ footer a:hover{
     cursor: pointer;
     opacity: 0.8;
 }
+/*for social media logos */
 
 .logo-container {
     display: flex;
     flex-direction: column;
     text-align: left;
     align-items: center;
-    gap: 22px;
+    gap: 1.5vh;
 }
 
 .footer-logo {

--- a/src/styles/components/infocard.css
+++ b/src/styles/components/infocard.css
@@ -1,18 +1,20 @@
-/*This is the card wrapper containing the card */
+/*This is the card wrapper containing the card for "what is empathy bytes" on the landing page*/
+
 .card-wrapper {
-    max-height:400px;
+    max-height:40vh;
 }
 /* The mui card component containing the card-content */
 .card {
     background-color: #003057;
     display: flex;
     max-width: 50vw;
-    height:400px;
+    height: 50vh;
     flex-direction: column;
     justify-content: space-evenly;
     align-items:center;
-    border-radius: 15px;
-    padding:0px 10px 0px 10px;
+    border-radius: 1vw;
+    padding: 2vw;
+    box-sizing: border-box;
 }
 
 /* The inner part of the card containing all the objects like the title, body, and button*/

--- a/src/styles/components/infocard.css
+++ b/src/styles/components/infocard.css
@@ -8,7 +8,7 @@
     background-color: #003057;
     display: flex;
     max-width: 50vw;
-    height: 50vh;
+    height: 52vh;
     flex-direction: column;
     justify-content: space-evenly;
     align-items:center;
@@ -22,7 +22,8 @@
     display:flex;
     flex-direction: column;
     align-items: flex-end;
-    gap:10px;
+    gap:2vh;
+    /*slightly increased the gap*/
 }
 
 
@@ -30,7 +31,7 @@
 .header {
     font-family: 'Roboto Slab', serif;
     color:white;
-    font-size: 30px;
+    font-size: 1.875rem;
     font-style: normal;
     font-weight: 700;
     line-height: normal;
@@ -40,24 +41,24 @@
 .content {
     color: #FFF;
     font-family: Roboto;
-    font-size: 24px;
+    font-size: 1.5rem;
     font-style: normal;
     font-weight: 400;
     line-height: normal;
 }
-
 /*The button for the card that links to another page*/
 .button {
     display: flex;
-    width: 200px;
-    height: 50px;
+    width: 12.5rem;
+    height: 3.125rem;
     justify-content: center;
     align-items: center;
-    gap: 20px;
-    border-radius: 50px;
+    gap: 1.25rem;
+    border-radius: 3.125rem;
     background: #004B87;
     flex-direction: row;
     align-self: flex-end;
+    /*doesn't look like its being used but replaced px with rem*/
     
 }
 

--- a/src/styles/components/interviewcard.css
+++ b/src/styles/components/interviewcard.css
@@ -1,7 +1,8 @@
 .int_card {
-    border-bottom: 5px solid #b3a369;
-    margin: 15px;
-    padding: 10px;
+    border-bottom: 0.3vw solid #b3a369;
+    margin: 1vw;
+    padding: 0.5vw;
+    box-sizing: border-box;
 }
 /*.summary {
     display: -webkit-box;
@@ -12,21 +13,21 @@
 }*/
 
 .img-style {
-    border-radius: 10px;
+    border-radius: 0.3vh;
     width: 20vw;
     height: 20vw;
     object-fit: cover;
 }
 
 .col {
-    padding: 10;
+    padding: 0.5vw;
     background-color: red;
 }
 
 .row {
     display: flex;
-    border-bottom: 5px solid #b3a369;
-    padding: 15;
+    border-bottom: 0.3vw solid #b3a369;
+    padding: 1vw;
     font-family: 'Roboto';
     justify-items: space-between;
 }


### PR DESCRIPTION
# Description

Changed the following CSS files sizing to go from pixels to vw/vh/%/rem.

articlePreview.css, footer.css, infocard.css, and interviewcard.css

Task ID: 24

## Type of change

- [ ] Bug fix 👾 (non-breaking change which fixes an issue)
- [x] New feature ✨ (non-breaking change which adds functionality)
- [ ] Breaking change 💥 (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update 📝

# Media
example code edited:
articlePreview.css
<img width="684" alt="Screenshot 2025-02-14 at 1 55 40 AM" src="https://github.com/user-attachments/assets/7652eaf4-d146-43c1-93d7-2cca632a99f2" />
footer.css
<img width="970" alt="Screenshot 2025-02-14 at 1 56 32 AM" src="https://github.com/user-attachments/assets/3f9d0d84-db4b-476a-abcb-89698c5041e9" />
infocard.css (this is for infocard on landing page "what is empathy bytes" and had to adjust sizing to match another file that is under ticket 3, I used 52vh for the .card since that's what it was changed to in the current branch for that ticket. 
<img width="753" alt="Screenshot 2025-02-14 at 1 58 39 AM" src="https://github.com/user-attachments/assets/3657a73f-0202-4de2-ba1f-c8bf3f0e0db6" />
interviewcard.css (for communities)
<img width="834" alt="Screenshot 2025-02-14 at 1 59 36 AM" src="https://github.com/user-attachments/assets/9d560c18-d36c-4b97-a2cc-3564be648875" />






# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
