### PR TITLE
Dynamic sizing for homepage, experiences, and experiencesIndividual

### DIFF
--- a/src/styles/experiences.css
+++ b/src/styles/experiences.css
@@ -29,8 +29,8 @@
 }
 
 .image-overlay {
-    width: 700px;
-    height: 500px;
+    width: 100%;
+    height: 100%;
     position: absolute;
     z-index: -10;
 }

--- a/src/styles/experiences.css
+++ b/src/styles/experiences.css
@@ -5,7 +5,7 @@
 
 .container-experiences-homepage {
     padding-top: calc(var(--navbar-scrolled-height) + 10vh);
-    padding-bottom: 90px;
+    padding-bottom: 20vh;
     background-color: #004B87;
 }
 .container-half {

--- a/src/styles/experiencesIndividual.css
+++ b/src/styles/experiencesIndividual.css
@@ -18,18 +18,18 @@
 
 .blue-box {
     background-color: #003057;
-    padding: 25px 50px;
-    border-radius: 20px;
-    width: 200vw;
-    max-width: calc(100% - 100px); /* to maintain .full-container-experience's 50px padding on each side */
+    padding: 4vh 5vw;
+    border-radius: 2vw;
+    width: 80vw;
+    max-width: calc(100% - 5vw); /* to maintain .full-container-experience's 50px padding on each side */
     margin: auto;
 }
 
 .divider {
-    margin: 50px auto;
+    margin: 10vh auto;
     background-color: #9CC6F5;
-    border-radius: 20px;
-    height: 3px;
+    border-radius: 2vh;
+    height: .5vh;
     width: 100vw;
     max-width: 50%;
 }
@@ -43,7 +43,7 @@
     font-family: 'Roboto', serif;
     font-size: 1rem;
     width: 175vw;
-    max-width: calc(100% - 100px);
+    max-width: calc(100% - 5vw);
     margin: auto;
 }
 
@@ -60,7 +60,7 @@ iframe {
 
 
 .full-container-experiences {
-    padding: 50px;
+    padding: 6vh;
     margin-bottom: var(--navbar-top-height);
     background-color: #004B87;
 }
@@ -88,7 +88,7 @@ iframe {
     font-size: 2rem;
     background-color: #004B87;
 
-    padding-left: 20px;
+    /*padding-left: 20px;*/
 
 }
 

--- a/src/styles/experiencesIndividual.css
+++ b/src/styles/experiencesIndividual.css
@@ -1,7 +1,7 @@
 @import "./fonts.css";
 
 .top-banner {
-    height: 450px;
+    height: 70vh;
     background-size: cover;
     display: flex;
     align-items: center;
@@ -20,7 +20,7 @@
     background-color: #003057;
     padding: 25px 50px;
     border-radius: 20px;
-    width: 1200px;
+    width: 200vw;
     max-width: calc(100% - 100px); /* to maintain .full-container-experience's 50px padding on each side */
     margin: auto;
 }
@@ -30,7 +30,7 @@
     background-color: #9CC6F5;
     border-radius: 20px;
     height: 3px;
-    width: 550px;
+    width: 100vw;
     max-width: 50%;
 }
 
@@ -42,7 +42,7 @@
 .paragraph-experiences-body {
     font-family: 'Roboto', serif;
     font-size: 1rem;
-    width: 800px;
+    width: 175vw;
     max-width: calc(100% - 100px);
     margin: auto;
 }
@@ -73,7 +73,7 @@ iframe {
         padding: 0; /* Adjust the padding for screens 600px or less */
     } 
 .vr-container-1 {
-    height: 500px;
+    height: 100vh;
     width: 100%;
     background-color: #abbfd0;
 }

--- a/src/styles/homepage.css
+++ b/src/styles/homepage.css
@@ -72,7 +72,7 @@ html, body {
 #learn-more-home .learn-more-home-section {
     background-color: #003057; /* Change to your desired background color */
     /* margin: 0px 150px 0px 150px; */
-    padding: 25px; /* Add padding or other styling as needed */
+    padding: 5vh; /* Add padding or other styling as needed */
     /* Center-align the text */
   }
 
@@ -85,7 +85,7 @@ html, body {
     justify-content: space-evenly;
     align-items: center;
     align-content: center;
-    height: 500px;
+    height: 65vh; /* CHANGED */
     overflow: inherit;
 
     /* mobile */
@@ -104,7 +104,7 @@ html, body {
 
 
 .info-wrapper {
-    gap:30px;
+    gap: 5%;
     font-family: 'Roboto Slab', serif;
     display: flex;
     justify-content: space-evenly;
@@ -151,7 +151,7 @@ html, body {
 /* atrributes for the team pic image */
 .teampic { 
     border-radius: 15px;
-    height:400px;
+    height: 52vh;
     max-width: 100%;
 
     /* mobile */
@@ -163,7 +163,7 @@ html, body {
 }
 
 .info-card {
-    height: 400px;
+    height: 40vh;
 }
 
 
@@ -171,7 +171,7 @@ html, body {
     text-align: center;
     font-family: 'Roboto', sans-serif;
 
-    font-size: 1.3vw;
+    font-size: 3vw;
     /* desktop */
     @media screen and (min-width: 600px) {
         font-size: 1.3vw;

--- a/src/styles/homepage.css
+++ b/src/styles/homepage.css
@@ -62,7 +62,6 @@ html, body {
 }
 
 #learn-more-home {
-    
     background-color: #004B87;
     padding-bottom: 7vh;
     height: 50vh;
@@ -99,7 +98,7 @@ html, body {
     justify-content: center;
     align-items: center;
     align-content: center;
-    gap:200px;
+    /*gap:200px;*/
 }
 
 
@@ -147,10 +146,11 @@ html, body {
         width: 90vw;
         height: 55vw;
     }
-}   
-/* atrributes for the team pic image */
+}
+
+/* Attributes for the team pic image */
 .teampic { 
-    border-radius: 15px;
+    border-radius: 3%;
     height: 52vh;
     max-width: 100%;
 
@@ -235,16 +235,17 @@ html, body {
 }
 
 
-/* Taken from My Portfolio Site */
+/* Arrows on Header*/
 .arrows {
-	width: 60px;
-	height: 72px;
+	width: 7%;
+	height: 80%;
+	/*Need changes for mobile screen*/
 }
 
 .arrows path {
 	stroke: #FFFFFF;
 	fill: transparent;
-	stroke-width: 2px;	
+	stroke-width: .5%;	
 	animation: arrow 4s infinite;
 	-webkit-animation: arrow 4s infinite; 
 }


### PR DESCRIPTION
# Description

Updated the homepage.css, experiences.css, and experiencesIndividual.css files to be able to size with the screen (dynamically sized). This means changing any attributes sized with px to vw/vh/%/rem instead, while keeping the design of the page the same.

Task ID: 26

## Type of change

- [ ] Bug fix 👾 (non-breaking change which fixes an issue)
- [x] New feature ✨ (non-breaking change which adds functionality)
- [ ] Breaking change 💥 (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update 📝

# Media

Example of css attributes which were initially sized with px changed to vw/vh/%/rem instead:
<img width="1129" alt="Screenshot 2025-02-14 at 2 47 34 AM" src="https://github.com/user-attachments/assets/d2c62f5c-db68-424f-8b3c-a590e5cb414e" />

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
