### PR TITLE
Gatsby Olympic Timeline Event Integration

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -26,6 +26,7 @@ module.exports = {
         filters: {
           "node--article": "filter[status][value]=1", // Only published articles
           "node--collection": "filter[status][value]=1", // Only published collections
+          "node--olympics_timeline_event": "filter[status][value]=1", // Only published timeline events
         },
         // Enable caching
         cache: true,
@@ -39,6 +40,11 @@ module.exports = {
           "node--collection": {
             "include": "field_image",
             "fields[node--collection]": "title,body,path,relationships",
+            "filter[status]": "1"
+          },
+          "node--olympics_timeline_event": {
+            "include": "field_field_event_images",
+            "fields[node--olympics_timeline_event]": "title,field_field_display_date,field_field_event_body,field_field_event_date,field_field_event_order,field_field_event_subtitle,field_field_event_title,field_field_event_url,path,relationships",
             "filter[status]": "1"
           }
         }
@@ -56,10 +62,6 @@ module.exports = {
     `gatsby-plugin-sharp`,
     `gatsby-transformer-sharp`,
     `gatsby-plugin-image`,
-    // new plugins
-    `gatsby-plugin-image`,
-    `gatsby-plugin-sharp`,
-    `gatsby-transformer-sharp`,
     {
       resolve: `gatsby-source-filesystem`,
       options: {

--- a/package-lock.json
+++ b/package-lock.json
@@ -28,8 +28,8 @@
         "react-icons": "^4.11.0",
         "react-material-ui-carousel": "^3.4.2",
         "react-multi-carousel": "^2.8.2",
-        "react-vertical-timeline-component": "^4.0.0",
         "react-photo-album": "^3.5.1",
+        "react-vertical-timeline-component": "^4.0.0",
         "styled-components": "^6.1.1",
         "three": "^0.169.0",
         "use-device-pixel-ratio": "^1.1.2",
@@ -5116,6 +5116,189 @@
       "integrity": "sha512-S9q47ByT2pPvD65IvrWp7qppVMpk9WGMbVq9wbWZOHg6tnXSD4vyhao6nOSBwwfDdV2p3Kx9evA9vI+XWTfDvw==",
       "license": "MIT"
     },
+    "node_modules/@typescript-eslint/eslint-plugin": {
+      "version": "4.33.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-4.33.0.tgz",
+      "integrity": "sha512-aINiAxGVdOl1eJyVjaWn/YcVAq4Gi/Yo35qHGCnqbWVz61g39D0h23veY/MA0rFFGfxK7TySg2uwDeNv+JgVpg==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@typescript-eslint/experimental-utils": "4.33.0",
+        "@typescript-eslint/scope-manager": "4.33.0",
+        "debug": "^4.3.1",
+        "functional-red-black-tree": "^1.0.1",
+        "ignore": "^5.1.8",
+        "regexpp": "^3.1.0",
+        "semver": "^7.3.5",
+        "tsutils": "^3.21.0"
+      },
+      "engines": {
+        "node": "^10.12.0 || >=12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "@typescript-eslint/parser": "^4.0.0",
+        "eslint": "^5.0.0 || ^6.0.0 || ^7.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@typescript-eslint/experimental-utils": {
+      "version": "4.33.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-4.33.0.tgz",
+      "integrity": "sha512-zeQjOoES5JFjTnAhI5QY7ZviczMzDptls15GFsI6jyUOq0kOf9+WonkhtlIhh0RgHRnqj5gdNxW5j1EvAyYg6Q==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@types/json-schema": "^7.0.7",
+        "@typescript-eslint/scope-manager": "4.33.0",
+        "@typescript-eslint/types": "4.33.0",
+        "@typescript-eslint/typescript-estree": "4.33.0",
+        "eslint-scope": "^5.1.1",
+        "eslint-utils": "^3.0.0"
+      },
+      "engines": {
+        "node": "^10.12.0 || >=12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "*"
+      }
+    },
+    "node_modules/@typescript-eslint/experimental-utils/node_modules/eslint-utils": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-3.0.0.tgz",
+      "integrity": "sha512-uuQC43IGctw68pJA1RgbQS8/NP7rch6Cwd4j3ZBtgo4/8Flj4eGE7ZYSZRN3iq5pVUv6GPdW5Z1RFleo84uLDA==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "eslint-visitor-keys": "^2.0.0"
+      },
+      "engines": {
+        "node": "^10.0.0 || ^12.0.0 || >= 14.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/mysticatea"
+      },
+      "peerDependencies": {
+        "eslint": ">=5"
+      }
+    },
+    "node_modules/@typescript-eslint/parser": {
+      "version": "4.33.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-4.33.0.tgz",
+      "integrity": "sha512-ZohdsbXadjGBSK0/r+d87X0SBmKzOq4/S5nzK6SBgJspFo9/CUDJ7hjayuze+JK7CZQLDMroqytp7pOcFKTxZA==",
+      "license": "BSD-2-Clause",
+      "peer": true,
+      "dependencies": {
+        "@typescript-eslint/scope-manager": "4.33.0",
+        "@typescript-eslint/types": "4.33.0",
+        "@typescript-eslint/typescript-estree": "4.33.0",
+        "debug": "^4.3.1"
+      },
+      "engines": {
+        "node": "^10.12.0 || >=12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^5.0.0 || ^6.0.0 || ^7.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@typescript-eslint/scope-manager": {
+      "version": "4.33.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-4.33.0.tgz",
+      "integrity": "sha512-5IfJHpgTsTZuONKbODctL4kKuQje/bzBRkwHE8UOZ4f89Zeddg+EGZs8PD8NcN4LdM3ygHWYB3ukPAYjvl/qbQ==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@typescript-eslint/types": "4.33.0",
+        "@typescript-eslint/visitor-keys": "4.33.0"
+      },
+      "engines": {
+        "node": "^8.10.0 || ^10.13.0 || >=11.10.1"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/types": {
+      "version": "4.33.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-4.33.0.tgz",
+      "integrity": "sha512-zKp7CjQzLQImXEpLt2BUw1tvOMPfNoTAfb8l51evhYbOEEzdWyQNmHWWGPR6hwKJDAi+1VXSBmnhL9kyVTTOuQ==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": "^8.10.0 || ^10.13.0 || >=11.10.1"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree": {
+      "version": "4.33.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-4.33.0.tgz",
+      "integrity": "sha512-rkWRY1MPFzjwnEVHsxGemDzqqddw2QbTJlICPD9p9I9LfsO8fdmfQPOX3uKfUaGRDFJbfrtm/sXhVXN4E+bzCA==",
+      "license": "BSD-2-Clause",
+      "peer": true,
+      "dependencies": {
+        "@typescript-eslint/types": "4.33.0",
+        "@typescript-eslint/visitor-keys": "4.33.0",
+        "debug": "^4.3.1",
+        "globby": "^11.0.3",
+        "is-glob": "^4.0.1",
+        "semver": "^7.3.5",
+        "tsutils": "^3.21.0"
+      },
+      "engines": {
+        "node": "^10.12.0 || >=12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@typescript-eslint/visitor-keys": {
+      "version": "4.33.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-4.33.0.tgz",
+      "integrity": "sha512-uqi/2aSz9g2ftcHWf8uLPJA70rUv6yuMW5Bohw+bwcuzaxQIHaKFZCKGoGXIrc9vkTJ3+0txM73K0Hq3d5wgIg==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@typescript-eslint/types": "4.33.0",
+        "eslint-visitor-keys": "^2.0.0"
+      },
+      "engines": {
+        "node": "^8.10.0 || ^10.13.0 || >=11.10.1"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
     "node_modules/@use-gesture/core": {
       "version": "10.3.1",
       "resolved": "https://registry.npmjs.org/@use-gesture/core/-/core-10.3.1.tgz",
@@ -5951,6 +6134,38 @@
       "resolved": "https://registry.npmjs.org/b4a/-/b4a-1.6.7.tgz",
       "integrity": "sha512-OnAYlL5b7LEkALw87fUVafQw5rVR9RjwGd4KUwNQ6DrrNmaVaUCgLipfVlzrPQ4tWOR9P0IXGNOx50jYCCdSJg==",
       "license": "Apache-2.0"
+    },
+    "node_modules/babel-eslint": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/babel-eslint/-/babel-eslint-10.1.0.tgz",
+      "integrity": "sha512-ifWaTHQ0ce+448CYop8AdrQiBsGrnC+bMgfyKFdi6EsPLTAWG+QfyDeM6OH+FmWnKvEq5NnBMLvlBUPKQZoDSg==",
+      "deprecated": "babel-eslint is now @babel/eslint-parser. This package will no longer receive updates.",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/code-frame": "^7.0.0",
+        "@babel/parser": "^7.7.0",
+        "@babel/traverse": "^7.7.0",
+        "@babel/types": "^7.7.0",
+        "eslint-visitor-keys": "^1.0.0",
+        "resolve": "^1.12.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "peerDependencies": {
+        "eslint": ">= 4.12.1"
+      }
+    },
+    "node_modules/babel-eslint/node_modules/eslint-visitor-keys": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.3.0.tgz",
+      "integrity": "sha512-6J72N8UNa462wa/KFODt/PJ3IU60SDpC3QXC1Hjc1BXXpfL2C9R5+AU7jhe0F6GREqVMh4Juu+NY7xn+6dipUQ==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "engines": {
+        "node": ">=4"
+      }
     },
     "node_modules/babel-jsx-utils": {
       "version": "1.1.0",
@@ -18710,6 +18925,20 @@
       "license": "MIT",
       "dependencies": {
         "is-typedarray": "^1.0.0"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.2.tgz",
+      "integrity": "sha512-bGdAIrZ0wiGDo5l8c++HWtbaNCWTS4UTv7RaTH/ThVIgjkveJt83m74bBHMJkuCbslY8ixgLBVZJIOiQlQTjfQ==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
       }
     },
     "node_modules/ua-parser-js": {

--- a/src/pages/olympic-timeline.js
+++ b/src/pages/olympic-timeline.js
@@ -100,6 +100,7 @@ const pageStyles = {
   },
 };
 
+// Helper for processing event images from Drupal, converts img relationships to array format
 const getEventImage = (relationships) => {
   const rawImages = relationships?.field_field_event_images;
 
@@ -120,12 +121,15 @@ function OlympicTimelinePage({ data }) {
 
   return (
     <Layout>
+      {/* Event body style override, avoids text white on white issue*/}
       <style>{`
         .timeline-event-body,
         .timeline-event-body * {
           color: #000 !important;
         }
       `}</style>
+
+      {/* Page header */}
       <section style={pageStyles.wrapper}>
         <h1 style={pageStyles.pageTitle}>Olympic Timeline Page</h1>
         <div style={pageStyles.intro}>
@@ -143,6 +147,7 @@ function OlympicTimelinePage({ data }) {
         </div>
 
         <VerticalTimeline>
+          {/* Pull data from query fields and perform basic checks */}
           {timelineEvents.map((eventNode, index) => {
             const eventTitle = eventNode?.field_field_event_title?.value || "Untitled Event";
             const eventSubtitle = eventNode?.field_field_event_subtitle?.value || "";
@@ -152,6 +157,7 @@ function OlympicTimelinePage({ data }) {
             const eventUrl = eventNode?.field_field_event_url?.value || "";
             const eventIcon = eventNode?.field_icon;
 
+            // Render each timeline event
             return (
               <VerticalTimelineElement
               key={eventNode?.id || `${eventTitle}-${index}`}

--- a/src/pages/olympic-timeline.js
+++ b/src/pages/olympic-timeline.js
@@ -1,79 +1,11 @@
 import React from "react";
 import { graphql } from "gatsby";
-import { GatsbyImage, getImage } from "gatsby-plugin-image";
 import {
   VerticalTimeline,
   VerticalTimelineElement,
 } from "react-vertical-timeline-component";
 import "react-vertical-timeline-component/style.min.css";
 import Layout from "../components/layout";
-
-// Timeline content is kept in one array so each event card can be rendered consistently.
-const timelineEvents = [
-  {
-    eventKey: "virtual-reality-gamble",
-    icon: "🎮",
-    date: "1989",
-    title: 'The "Virtual Reality" Gamble',
-    subtitle: "Atlanta's Olympic bid gets a tech-forward edge",
-    description:
-      "Instead of a traditional cardboard model, Georgia Tech President John P. Crecine proposed a cutting-edge virtual reality fly-through to give Atlanta a technological edge. Undergraduates and faculty linked the campus's supercomputers to process the massive amounts of data required for the computer animation.",
-  },
-  {
-    eventKey: "high-tech-southern-hospitality",
-    icon: "🌎",
-    date: "September 1990",
-    title: "High-Tech Southern Hospitality",
-    subtitle: "The presentation becomes Atlanta's secret weapon",
-    description:
-      `The completed interactive presentation was showcased at the 96th IOC Congress in Tokyo. IOC members used a trackball to navigate a 3D model of the city and village, an innovation deemed Atlanta's "secret weapon". After winning the bid, Andrew Young famously attributed the victory to this "high-tech Southern hospitality".`,
-  },
-  {
-    eventKey: "108-million-makeover",
-    icon: "🏗️",
-    date: "1991-1996",
-    title: "The $108 Million Makeover",
-    subtitle: "Campus housing transforms for 15,000 athletes",
-    description:
-      "To prepare for 15,000 athletes, Georgia Tech invested $108.3 million to build seven apartment-style residence halls. This massive construction project permanently changed Georgia Tech, almost doubling its housing inventory so that 70 percent of the undergraduate student body could live on campus.",
-  },
-  {
-    eventKey: "defusing-a-nuclear-threat",
-    icon: "☢️",
-    date: "November 1995",
-    title: "Defusing a Nuclear Threat",
-    subtitle: "Olympic security reaches the Neely reactor",
-    description:
-      "Because the Georgia Tech campus housed the Neely Nuclear Research Center, a fully functional research reactor, federal authorities raised severe security concerns regarding potential terror attacks on the Olympic Village. On November 17, 1995, the reactor was permanently shut down, and its highly enriched uranium fuel was shipped off-site by February 1996.",
-  },
-  {
-    eventKey: "the-bubble-closes",
-    icon: "🔒",
-    date: "July 1, 1996",
-    title: "The Bubble Closes",
-    subtitle: "Georgia Tech becomes the Olympic Village",
-    description:
-      `On July 1, 1996, the campus was officially closed to the public to finalize preparations. A high, electrified fence was constructed around the perimeter, turning the academic community into a heavily fortified Olympic Village that functioned as the "sixth-largest city in Georgia" for five weeks.`,
-  },
-  {
-    eventKey: "unlimited-big-macs-and-early-email",
-    icon: "🍔",
-    date: "July 19 - August 4, 1996",
-    title: "Unlimited Big Macs & Early Email",
-    subtitle: "Global athletes meet early internet culture",
-    description:
-      `Athletes dined at a massive, full-service McDonald's tent on campus, where professional volleyball player Kent Steffes noted that athletes from around the world were walking away with stacks of six Big Macs per plate. Next door, IBM built the "Surf Shack," a colorful internet cafe where athletes were introduced to early digital technology and provided with individual email accounts for fan mail.`,
-  },
-  {
-    eventKey: "the-center-of-the-world",
-    icon: "🏅",
-    date: "Summer 1996",
-    title: "The Center of the World",
-    subtitle: "Georgia Tech takes the international spotlight",
-    description:
-      "The Kessler Campanile, an 80-foot stainless steel obelisk built specifically for the Olympics, served as the daily broadcasting backdrop for NBC's The Today Show. Additionally, 44 athletes and coaches affiliated with Georgia Tech proudly participated in the Centennial Games.",
-  },
-];
 
 const pageStyles = {
   wrapper: {
@@ -143,19 +75,32 @@ const pageStyles = {
     justifyContent: "center",
     width: "100%",
   },
+  eventLink: {
+    color: "#00548f",
+    display: "inline-block",
+    fontWeight: 600,
+    marginTop: "0.85rem",
+    textDecoration: "underline",
+  },
 };
 
-const normalizeImageKey = (value) => value?.trim().toLowerCase();
+const getEventImage = (relationships) => {
+  const rawImages = relationships?.field_field_event_images;
+
+  if (!rawImages) {
+    return [];
+  }
+
+  const images = Array.isArray(rawImages) ? rawImages : [rawImages];
+
+  return images.map((img) => ({
+    src: img?.uri?.url || img?.url || "",
+    alt: img?.alt || "",
+  }));
+};
 
 function OlympicTimelinePage({ data }) {
-  const imageMap = {};
-
-  // Normalize both filenames and event keys so small casing differences do not break image lookups.
-  data.timelineImages.nodes.forEach((node) => {
-    imageMap[normalizeImageKey(node.name)] = getImage(
-      node.childImageSharp?.gatsbyImageData
-    );
-  });
+  const timelineEvents = data?.timelineEvents?.nodes || [];
 
   return (
     <Layout>
@@ -176,28 +121,59 @@ function OlympicTimelinePage({ data }) {
         </div>
 
         <VerticalTimeline>
-          {timelineEvents.map((event) => (
-            <VerticalTimelineElement
-              key={event.eventKey}
-              date={event.date}
+          {timelineEvents.map((eventNode, index) => {
+            const eventTitle = eventNode?.field_field_event_title?.value || "Untitled Event";
+            const eventSubtitle = eventNode?.field_field_event_subtitle?.value || "";
+            const eventDate = eventNode?.field_field_display_date?.value || eventNode?.field_field_event_date || "";
+            const eventDescriptionHtml = eventNode?.field_field_event_body?.processed || "";
+            const eventImages = getEventImage(eventNode?.relationships);
+            const eventUrl = eventNode?.field_field_event_url?.uri || eventNode?.field_field_event_url?.url || "";
+
+            return (
+              <VerticalTimelineElement
+              key={eventNode?.id || `${eventTitle}-${index}`}
+              date={eventDate}
               contentStyle={{ background: "#fff", color: "#000" }}
               contentArrowStyle={{ borderRight: "7px solid #fff" }}
               iconStyle={{ background: "#003057", color: "#fff" }}
-              icon={<span style={pageStyles.icon}>{event.icon}</span>}
+              icon={<span style={pageStyles.icon}>🏅</span>}
             >
-              <h3>{event.title}</h3>
-              <p style={pageStyles.subtitle}>{event.subtitle}</p>
-              <p style={pageStyles.description}>{event.description}</p>
+              <h3>{eventTitle}</h3>
+              {eventSubtitle && <p style={pageStyles.subtitle}>{eventSubtitle}</p>}
 
-              {imageMap[normalizeImageKey(event.eventKey)] && (
-                <GatsbyImage
-                  image={imageMap[normalizeImageKey(event.eventKey)]}
-                  alt={event.title}
-                  style={pageStyles.image}
+              {eventDescriptionHtml ? (
+                <div
+                  style={pageStyles.description}
+                  dangerouslySetInnerHTML={{ __html: eventDescriptionHtml }}
                 />
+              ) : (
+                <p style={pageStyles.description}>No event description available.</p>
+              )}
+
+              {eventImages.map((image, idx) => (
+                image.src && (
+                  <img
+                    key={idx}
+                    src={image.src}
+                    alt={image.alt || eventTitle}
+                    style={pageStyles.image}
+                  />
+                )
+              ))}
+
+              {eventUrl && (
+                <a
+                  href={eventUrl}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  style={pageStyles.eventLink}
+                >
+                  Learn more
+                </a>
               )}
             </VerticalTimelineElement>
-          ))}
+            );
+          })}
         </VerticalTimeline>
       </section>
     </Layout>
@@ -214,22 +190,38 @@ export const Head = () => (
 
 export const query = graphql`
   query OlympicTimelineQuery {
-    timelineImages: allFile(
-      filter: {
-        sourceInstanceName: { eq: "olympic-timeline-images" }
-        extension: { regex: "/(jpg|jpeg|png)/" }
-      }
-      sort: { name: ASC }
+    timelineEvents: allNodeOlympicsTimelineEvent(
+      sort: { field_field_event_order: ASC }
     ) {
       nodes {
         id
-        name
-        childImageSharp {
-          gatsbyImageData(
-            width: 1200
-            placeholder: BLURRED
-            formats: [AUTO, WEBP]
-          )
+        title
+        field_field_display_date {
+          value
+        }
+        field_field_event_body {
+          processed
+        }
+        field_field_event_date
+        field_field_event_order
+        field_field_event_subtitle {
+          value
+        }
+        field_field_event_title {
+          value
+        }
+        field_field_event_url {
+          uri
+          url
+        }
+        relationships {
+          field_field_event_images {
+            alt
+            url
+            uri {
+              url
+            }
+          }
         }
       }
     }

--- a/src/pages/olympic-timeline.js
+++ b/src/pages/olympic-timeline.js
@@ -51,7 +51,7 @@ const pageStyles = {
     textAlign: "center",
   },
   subtitle: {
-    margin: "0.4rem 0 0.9rem",
+    margin: 0,
     color: "#555",
     fontWeight: 600,
   },
@@ -59,13 +59,29 @@ const pageStyles = {
     color: "#1f1f1f",
     fontSize: "1rem",
     lineHeight: 1.7,
-    margin: "0",
+    margin: 0,
     textAlign: "left",
   },
-  image: {
+  cardTitle: {
+    margin: "0 0 0.9rem",
+  },
+  textStack: {
+    display: "flex",
+    flexDirection: "column",
+    gap: "0.4rem",
+  },
+  imageContainer: {
     marginTop: "1rem",
     borderRadius: "12px",
     overflow: "hidden",
+    width: "100%",
+    background: "#f6f7f9",
+  },
+  image: {
+    display: "block",
+    width: "100%",
+    height: "auto",
+    maxWidth: "100%",
   },
   icon: {
     alignItems: "center",
@@ -94,8 +110,8 @@ const getEventImage = (relationships) => {
   const images = Array.isArray(rawImages) ? rawImages : [rawImages];
 
   return images.map((img) => ({
-    src: img?.uri?.url || img?.url || "",
-    alt: img?.alt || "",
+    src: img?.relationships?.field_media_hg_image?.url || "",
+    alt: img?.field_media_hg_image?.alt || img?.name || "",
   }));
 };
 
@@ -104,6 +120,12 @@ function OlympicTimelinePage({ data }) {
 
   return (
     <Layout>
+      <style>{`
+        .timeline-event-body,
+        .timeline-event-body * {
+          color: #000 !important;
+        }
+      `}</style>
       <section style={pageStyles.wrapper}>
         <h1 style={pageStyles.pageTitle}>Olympic Timeline Page</h1>
         <div style={pageStyles.intro}>
@@ -127,7 +149,8 @@ function OlympicTimelinePage({ data }) {
             const eventDate = eventNode?.field_field_display_date?.value || eventNode?.field_field_event_date || "";
             const eventDescriptionHtml = eventNode?.field_field_event_body?.processed || "";
             const eventImages = getEventImage(eventNode?.relationships);
-            const eventUrl = eventNode?.field_field_event_url?.uri || eventNode?.field_field_event_url?.url || "";
+            const eventUrl = eventNode?.field_field_event_url?.value || "";
+            const eventIcon = eventNode?.field_icon;
 
             return (
               <VerticalTimelineElement
@@ -136,28 +159,32 @@ function OlympicTimelinePage({ data }) {
               contentStyle={{ background: "#fff", color: "#000" }}
               contentArrowStyle={{ borderRight: "7px solid #fff" }}
               iconStyle={{ background: "#003057", color: "#fff" }}
-              icon={<span style={pageStyles.icon}>🏅</span>}
+              icon={<span style={pageStyles.icon}>{eventIcon}</span>}
             >
-              <h3>{eventTitle}</h3>
-              {eventSubtitle && <p style={pageStyles.subtitle}>{eventSubtitle}</p>}
+              <div style={pageStyles.textStack}>
+                <h3 style={pageStyles.cardTitle}>{eventTitle}</h3>
+                {eventSubtitle && <p style={pageStyles.subtitle}>{eventSubtitle}</p>}
 
-              {eventDescriptionHtml ? (
-                <div
-                  style={pageStyles.description}
-                  dangerouslySetInnerHTML={{ __html: eventDescriptionHtml }}
-                />
-              ) : (
-                <p style={pageStyles.description}>No event description available.</p>
-              )}
+                {eventDescriptionHtml ? (
+                  <div
+                    className="timeline-event-body"
+                    style={pageStyles.description}
+                    dangerouslySetInnerHTML={{ __html: eventDescriptionHtml }}
+                  />
+                ) : (
+                  <p style={pageStyles.description}>No event description available.</p>
+                )}
+              </div>
 
               {eventImages.map((image, idx) => (
                 image.src && (
-                  <img
-                    key={idx}
-                    src={image.src}
-                    alt={image.alt || eventTitle}
-                    style={pageStyles.image}
-                  />
+                  <div key={idx} style={pageStyles.imageContainer}>
+                    <img
+                      src={image.src}
+                      alt={image.alt || eventTitle}
+                      style={pageStyles.image}
+                    />
+                  </div>
                 )
               ))}
 
@@ -211,15 +238,19 @@ export const query = graphql`
           value
         }
         field_field_event_url {
-          uri
-          url
+          value
         }
+        field_icon
         relationships {
           field_field_event_images {
-            alt
-            url
-            uri {
-              url
+            name
+            field_media_hg_image {
+              alt
+            }
+            relationships {
+              field_media_hg_image {
+                url
+              }
             }
           }
         }


### PR DESCRIPTION
# Description

Implementation of Drupal content into the Olympic timeline page to allow for page content modification without actual code changes. Changed hardcoded data to instead pull from olympic_timeline_event content in Drupal. Additionally, made some changes to the olympic_timeline_event content type to better match the initial site provided by frontend.

Task ID: 94

## Type of change

- [x] New feature ✨ (non-breaking change which adds functionality)

# Media

Visuals simply match what was initially provided by frontend: 
<img width="1851" height="975" alt="image" src="https://github.com/user-attachments/assets/d3fab01c-6eb3-48f8-ba92-5c6d4b7f52b1" />
(Zoomed out sample image)

<img width="498" height="888" alt="image" src="https://github.com/user-attachments/assets/02da1947-8a18-4144-8fb8-99c7b5da0b1c" />
<img width="911" height="199" alt="image" src="https://github.com/user-attachments/assets/f31b1537-68d5-40a3-97e6-8fd209833d2b" />
(Some Code Snippets)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
